### PR TITLE
Rename 'Odd Scots' to 'Oddz godz'

### DIFF
--- a/named-siteswaps.txt
+++ b/named-siteswaps.txt
@@ -54,7 +54,7 @@
 9964786 7 club Jim's 2 count (variation)
 9784966 7 club Jim's 2 count (variation)
 9784786 7 club Jim's 2 count (variation)
-b64 Odd Scots
+b64 Oddz godz
 726778827 Self Centered
 7747746677466 Jim's ppsps (async)
 8686777 Vitoria


### PR DESCRIPTION
I assume this was a typo/autocorrect at some point. Only uses I can find are your website and passist.

Highgate collection/passing pattern compendium calls (the sync version of) this 'Oddz godz' and that's what I learnt it as. In the same way I would call 7746666 Jim's 3c, I would call this Oddz godz.